### PR TITLE
add rpi_matrixkeypad_simpletest.py with pin mappings for pi

### DIFF
--- a/examples/matrixkeypad_simpletest.py
+++ b/examples/matrixkeypad_simpletest.py
@@ -6,10 +6,12 @@ import adafruit_matrixkeypad
 # Membrane 3x4 matrix keypad - https://www.adafruit.com/product/419
 cols = [digitalio.DigitalInOut(x) for x in (board.D9, board.D6, board.D5)]
 rows = [digitalio.DigitalInOut(x) for x in (board.D13, board.D12, board.D11, board.D10)]
+
 # 3x4 matrix keypad - Rows and columns are mixed up for https://www.adafruit.com/product/3845
 # Use the same wiring as in the guide with the following setup lines:
 # cols = [digitalio.DigitalInOut(x) for x in (board.D11, board.D13, board.D9)]
 # rows = [digitalio.DigitalInOut(x) for x in (board.D12, board.D5, board.D6, board.D10)]
+
 keys = ((1, 2, 3),
         (4, 5, 6),
         (7, 8, 9),

--- a/examples/rpi_matrixkeypad_simpletest.py
+++ b/examples/rpi_matrixkeypad_simpletest.py
@@ -3,11 +3,13 @@ import digitalio
 import board
 import adafruit_matrixkeypad
 
-# Membrane 3x4 matrix keypad on Raspberry Pi - https://www.adafruit.com/product/419
+# Membrane 3x4 matrix keypad on Raspberry Pi -
+# https://www.adafruit.com/product/419
 cols = [digitalio.DigitalInOut(x) for x in (board.D26, board.D20, board.D21)]
 rows = [digitalio.DigitalInOut(x) for x in (board.D5, board.D6, board.D13, board.D19)]
 
-# 3x4 matrix keypad on Raspberry Pi - Rows and columns are mixed up for https://www.adafruit.com/product/3845
+# 3x4 matrix keypad on Raspberry Pi -
+# rows and columns are mixed up for https://www.adafruit.com/product/3845
 # cols = [digitalio.DigitalInOut(x) for x in (board.D13, board.D5, board.D26)]
 # rows = [digitalio.DigitalInOut(x) for x in (board.D6, board.D21, board.D20, board.D19)]
 

--- a/examples/rpi_matrixkeypad_simpletest.py
+++ b/examples/rpi_matrixkeypad_simpletest.py
@@ -1,0 +1,25 @@
+import time
+import digitalio
+import board
+import adafruit_matrixkeypad
+
+# Membrane 3x4 matrix keypad on Raspberry Pi - https://www.adafruit.com/product/419
+cols = [digitalio.DigitalInOut(x) for x in (board.D26, board.D20, board.D21)]
+rows = [digitalio.DigitalInOut(x) for x in (board.D5, board.D6, board.D13, board.D19)]
+
+# 3x4 matrix keypad on Raspberry Pi - Rows and columns are mixed up for https://www.adafruit.com/product/3845
+# cols = [digitalio.DigitalInOut(x) for x in (board.D13, board.D5, board.D26)]
+# rows = [digitalio.DigitalInOut(x) for x in (board.D6, board.D21, board.D20, board.D19)]
+
+keys = ((1, 2, 3),
+        (4, 5, 6),
+        (7, 8, 9),
+        ('*', 0, '#'))
+
+keypad = adafruit_matrixkeypad.Matrix_Keypad(rows, cols, keys)
+
+while True:
+    keys = keypad.pressed_keys
+    if keys:
+        print("Pressed: ", keys)
+    time.sleep(0.1)


### PR DESCRIPTION
Based on Fritzings in guide: https://learn.adafruit.com/matrix-keypad/python-circuitpython

The 3x4 rigid one is tested.  Extrapolating from there for the membrane pinout.